### PR TITLE
Fix: global auths not working

### DIFF
--- a/src/Auth_Command.php
+++ b/src/Auth_Command.php
@@ -264,7 +264,6 @@ class Auth_Command extends EE_Command {
 	}
 
 	/**
-	 * @todo
 	 * Generates auth files for global auth and all sites.
 	 *
 	 * @param bool $clean_auths syncs the auth_user table with htpasswd file (default: false).
@@ -279,26 +278,11 @@ class Auth_Command extends EE_Command {
 			EE::warning( 'Cleaned htpasswd at ' . EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default' );
 		}  // Clean the existing `admin-tools` | `global` auths for proper synchronization.
 		
-		$global_admin_tools_auths = Auth::get_global_admin_tools_auth();
-		$global_auths             = Auth::get_global_auths();
+		$auths = 'default_admin_tools' === $site ? Auth::get_global_admin_tools_auth() : Auth::get_global_auths();
 
-		switch ( $site ) {
-			case 'default_admin_tools':
-				EE::log( 'Generating auth file(s) for `default_admin_tools`...' );
-				break;
-			case 'default':
-				EE::log( 'Generating auth file(s) for `default`...' );
-				$this->generate_default_auth_files( $global_auths );
-				break;
-			default:
-				return;
-		}
-	}
-
-	private function generate_default_auth_files( $auths ) {
 		foreach ( $auths as $auth ) {
 			if ( ! empty( $auth ) ) {
-				EE::exec( sprintf( 'docker exec %s htpasswd -bc /etc/nginx/htpasswd/default %s %s', EE_PROXY_TYPE, $auth->username, $auth->password ) );
+				EE::exec( sprintf( 'docker exec %1$s htpasswd -bc /etc/nginx/htpasswd/%2$s %3$s %4$s', EE_PROXY_TYPE, $site, $auth->username, $auth->password ) );
 			} 
 		}
 		
@@ -314,7 +298,7 @@ class Auth_Command extends EE_Command {
 					$flags = 'bc';
 				}
 
-				EE::exec( sprintf( 'docker exec %s htpasswd -%s /etc/nginx/htpasswd/default %s %s', EE_PROXY_TYPE, $flags, $auth->username, $auth->password ) );
+				EE::exec( sprintf( 'docker exec %1$s htpasswd -%2$s /etc/nginx/htpasswd/%3$ %4$s %5$s', EE_PROXY_TYPE, $flags, $site, $auth->username, $auth->password ) );
 			}
 		}
 

--- a/src/Auth_Command.php
+++ b/src/Auth_Command.php
@@ -173,7 +173,7 @@ class Auth_Command extends EE_Command {
 		Auth::create( $auth_data );
 
 		if ( 'default' === $site_url ) {
-			$this->generate_global_auth_files( true );
+			$this->generate_global_auth_files( $site_url );
 		} else {
 			$this->generate_site_auth_files( $site_url );
 		}
@@ -267,92 +267,67 @@ class Auth_Command extends EE_Command {
 	 * @todo
 	 * Generates auth files for global auth and all sites.
 	 *
-	 * @param bool $clean_admin_auths syncs the auth_user table with htpasswd file (default: false).
+	 * @param bool $clean_auths syncs the auth_user table with htpasswd file (default: false).
 	 * @throws Exception
 	 */
-	private function generate_global_auth_files( $clean_admin_auths = false ) {
-
+	private function generate_global_auth_files( $site = 'default', $clean_auths = false ) {
+		if ( $clean_auths && 'default_admin_tools' === $site ) {
+			$this->fs->remove( EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default_admin_tools' );
+			EE::warning( 'Cleaned htpasswd at ' . EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default_admin_tools' );
+		} else if ( $clean_auths && 'default' === $site ) {
+			$this->fs->remove( EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default' );
+			EE::warning( 'Cleaned htpasswd at ' . EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default' );
+		}  // Clean the existing `admin-tools` | `global` auths for proper synchronization.
+		
 		$global_admin_tools_auths = Auth::get_global_admin_tools_auth();
 		$global_auths             = Auth::get_global_auths();
 
-		if ( $clean_admin_auths ) {
-			$this->fs->remove( EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default_admin_tools' );
-			EE::warning( 'Cleaned htpasswd at ' . EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default_admin_tools' );
+		switch ( $site ) {
+			case 'default_admin_tools':
+				EE::log( 'Generating auth file(s) for `default_admin_tools`...' );
+				break;
+			case 'default':
+				EE::log( 'Generating auth file(s) for `default`...' );
+				$this->generate_default_auth_files( $global_auths );
+				break;
+			default:
+				return;
+		}
+	}
 
-			$this->fs->remove( EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default' );
-			EE::warning( 'Cleaned htpasswd at ' . EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default' );
-		} // Clean the existing `admin-tools` auth for proper synchronization.
+	private function generate_default_auth_files( $auths ) {
+		foreach ( $auths as $auth ) {
+			if ( ! empty( $auth ) ) {
+				EE::exec( sprintf( 'docker exec %s htpasswd -bc /etc/nginx/htpasswd/default %s %s', EE_PROXY_TYPE, $auth->username, $auth->password ) );
+			} 
+		}
+		
+		$auths = Auth::get_global_auths();
 
-		foreach ( $global_admin_tools_auths as $global_admin_tools_auth ) {
-			if ( ! empty( $global_admin_tools_auth ) ) {
-				EE::exec( sprintf( 'docker exec %s htpasswd -bc /etc/nginx/htpasswd/default_admin_tools %s %s', EE_PROXY_TYPE, $global_admin_tools_auth->username, $global_admin_tools_auth->password ) );
-			} else {
-				$this->fs->remove( EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default_admin_tools' );
-				$this->fs->remove( EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default' );
-				$auths = Auth::get_global_auths();
-	
-				if ( empty( $auths ) ) {
-					$this->regen_admin_tools_auth();
-				} else {
-					foreach ( $auths as $key => $auth ) {
-						$flags = 'b';
-	
-						if ( 0 === $key ) {
-							$flags = 'bc';
-						}
-	
-						EE::exec( sprintf( 'docker exec %s htpasswd -%s /etc/nginx/htpasswd/default %s %s', EE_PROXY_TYPE, $flags, $auth->username, $auth->password ) );
-					}
+		if ( empty( $auths ) ) {
+			$this->regen_admin_tools_auth();
+		} else {
+			foreach ( $auths as $key => $auth ) {
+				$flags = 'b';
+
+				if ( 0 === $key ) {
+					$flags = 'bc';
 				}
-	
-				$sites = array_unique(
-					array_column(
-						Auth::all( array( 'site_url' ) ),
-						'site_url'
-					)
-				);
-	
-				foreach ( $sites as $site ) {
-					$this->generate_site_auth_files( $site );
-				}
+
+				EE::exec( sprintf( 'docker exec %s htpasswd -%s /etc/nginx/htpasswd/default %s %s', EE_PROXY_TYPE, $flags, $auth->username, $auth->password ) );
 			}
 		}
 
-		foreach ( $global_auths as $global_auth ) {
-			if ( ! empty( $global_auth ) ) {
-				EE::exec( sprintf( 'docker exec %s htpasswd -bc /etc/nginx/htpasswd/default %s %s', EE_PROXY_TYPE, $global_auth->username, $global_auth->password ) );
-			} else {
-				$this->fs->remove( EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default_admin_tools' );
-				$this->fs->remove( EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/default' );
-				$auths = Auth::get_global_auths();
-	
-				if ( empty( $auths ) ) {
-					$this->regen_admin_tools_auth();
-				} else {
-					foreach ( $auths as $key => $auth ) {
-						$flags = 'b';
-	
-						if ( 0 === $key ) {
-							$flags = 'bc';
-						}
-	
-						EE::exec( sprintf( 'docker exec %s htpasswd -%s /etc/nginx/htpasswd/default %s %s', EE_PROXY_TYPE, $flags, $auth->username, $auth->password ) );
-					}
-				}
-	
-				$sites = array_unique(
-					array_column(
-						Auth::all( array( 'site_url' ) ),
-						'site_url'
-					)
-				);
-	
-				foreach ( $sites as $site ) {
-					$this->generate_site_auth_files( $site );
-				}
-			}
-		}
+		$sites = array_unique(
+			array_column(
+				Auth::all( array( 'site_url' ) ),
+				'site_url'
+			)
+		);
 
+		foreach ( $sites as $site ) {
+			$this->generate_site_auth_files( $site );
+		}
 	}
 
 	/**
@@ -522,7 +497,7 @@ class Auth_Command extends EE_Command {
 		}
 
 		if ( 'default' === $site_url ) {
-			$this->generate_global_auth_files();
+			$this->generate_global_auth_files( $site_url );
 		} else {
 			$this->generate_site_auth_files( $site_url );
 		}
@@ -673,7 +648,7 @@ class Auth_Command extends EE_Command {
 			}
 
 			if ( 'default' === $site_url ) {
-				$this->generate_global_auth_files();
+				$this->generate_global_auth_files( $site_url );
 			} else {
 				$this->generate_site_auth_files( $site_url );
 			}


### PR DESCRIPTION
Due to changes in `generate_global_auth_files()`, the command `ee auth create global` successfully executed and stored the auth in `auth_users` table; however, the auth did not work on the site. This was due to some logical errors in `generate_global_auth_files()`. 